### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 env:
   AZURE_WEBAPP_PACKAGE_PATH: "./src/OweMe.Api/publish"
   SOLUTION_PATH: "./src/OweMe.Api.sln"
@@ -16,6 +19,8 @@ jobs:
   build-and-test:
     name: Build, Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +55,9 @@ jobs:
     name: Deploy to Azure
     runs-on: ubuntu-latest
     needs: [ build-and-test ]
+    permissions:
+      contents: read
+      deployments: write
 
     steps:
       - name: Download published artifact


### PR DESCRIPTION
Potential fix for [https://github.com/MrD4rkne/owe-me-api/security/code-scanning/5](https://github.com/MrD4rkne/owe-me-api/security/code-scanning/5)

To address the issue, explicit permissions should be added to the workflow to limit the `GITHUB_TOKEN` access. Permissions should be set at the workflow level or job level, specifying only the required privileges for each job.

For this workflow, the `build-and-test` job primarily requires read access to the repository contents, while the `deploy` job might require write access to pull requests (if applicable) or other granular permissions necessary for deployment. Adding permissions blocks with minimal required privileges ensures secure operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
