### PR TITLE
feat: add validation to the pipeline, rename behaviour

### DIFF
--- a/src/OweMe.Application.UnitTests/Common/Behaviours/ValidationPipelineBehaviourTests.cs
+++ b/src/OweMe.Application.UnitTests/Common/Behaviours/ValidationPipelineBehaviourTests.cs
@@ -8,9 +8,9 @@ using Shouldly;
 
 namespace OweMe.Application.UnitTests.Common.Behaviours;
 
-using LocalValidationBehaviour = ValidationBehaviour<TestRequest, string>;
+using LocalValidationBehaviour = ValidationPipelineBehaviour<TestRequest, string>;
 
-public class ValidationBehaviourTests
+public class ValidationPipelineBehaviourTests
 {
     [Fact]
     public void Constructor_Should_Throw_When_LoggerIsNull()

--- a/src/OweMe.Application.UnitTests/Common/Behaviours/ValidationPipelineBehaviourTests.cs
+++ b/src/OweMe.Application.UnitTests/Common/Behaviours/ValidationPipelineBehaviourTests.cs
@@ -100,13 +100,10 @@ public class ValidationPipelineBehaviourTests
         var next = new RequestHandlerDelegate<string>(_ => Task.FromResult("ok"));
 
         // Act
-        await Record.ExceptionAsync(async () =>
-        {
-            string result = await sut.Handle(new TestRequest { Value = "request" }, next, CancellationToken.None);
+        var result = await sut.Handle(new TestRequest { Value = "request" }, next, CancellationToken.None);
 
-            // Assert
-            result.ShouldBe("ok");
-        });
+        // Assert
+        result.ShouldBe("ok");
     }
 
     [Fact]

--- a/src/OweMe.Application/Common/Behaviours/ValidationPipelineBehaviour.cs
+++ b/src/OweMe.Application/Common/Behaviours/ValidationPipelineBehaviour.cs
@@ -4,12 +4,12 @@ using Microsoft.Extensions.Logging;
 
 namespace OweMe.Application.Common.Behaviours;
 
-public class ValidationBehaviour<TRequest, TResponse>(
-    ILogger<ValidationBehaviour<TRequest, TResponse>> logger,
+public class ValidationPipelineBehaviour<TRequest, TResponse>(
+    ILogger<ValidationPipelineBehaviour<TRequest, TResponse>> logger,
     IEnumerable<IValidator<TRequest>> validators)
     : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
 {
-    private readonly ILogger<ValidationBehaviour<TRequest, TResponse>> _logger =
+    private readonly ILogger<ValidationPipelineBehaviour<TRequest, TResponse>> _logger =
         logger ?? throw new ArgumentNullException(nameof(logger));
 
     private readonly IEnumerable<IValidator<TRequest>> _validators =

--- a/src/OweMe.Application/DependencyInjection.cs
+++ b/src/OweMe.Application/DependencyInjection.cs
@@ -19,5 +19,6 @@ public static class DependencyInjection
 
         builder.Services.AddScoped(typeof(IPipelineBehavior<,>), typeof(LoggingPipelineBehaviour<,>));
         builder.Services.AddScoped(typeof(IPipelineBehavior<,>), typeof(PerformancePipelineBehaviour<,>));
+        builder.Services.AddScoped(typeof(IPipelineBehavior<,>), typeof(ValidationPipelineBehaviour<,>));
     }
 }

--- a/src/compose.debug.yaml
+++ b/src/compose.debug.yaml
@@ -23,6 +23,7 @@
       # IdentityServer configuration
       - IdentityServer__Authority=http://identity:8180
       - IdentityServer__ValidIssuer=https://localhost:8181
+      - IdentityServer__ValidateAudience=false
     volumes:
       - ~/.aspnet/https:/https:ro
   oweme.seq:


### PR DESCRIPTION
- add validation to Mediator pipeline

Proof it works:
`POST /api/ledgers HTTP/1.1
Content-Type: application/json
Authorization: Bearer <token>
User-Agent: PostmanRuntime/7.44.1
Accept: */*
Cache-Control: no-cache
Postman-Token: fe5c0291-24fc-49f7-b83f-d570ebda3faa
Host: localhost:8081
Accept-Encoding: gzip, deflate, br
Connection: keep-alive
Content-Length: 47
 
{
"name":"",
"description": "dupa"
}
 
HTTP/1.1 500 Internal Server Error
Content-Type: text/plain; charset=utf-8
Date: Wed, 16 Jul 2025 08:14:44 GMT
Server: Kestrel
Transfer-Encoding: chunked
 
FluentValidation.ValidationException: Validation failed:
-- Name: Ledger name is required. Severity: Error
at OweMe.Application.Common.Behaviours.ValidationPipelineBehaviour`2.ValidateAndThrowIfInvalid(ValidationContext`1 context, CancellationToken cancellationToken) in C:\Users\mszo\source\personal\owe-me-api\src\OweMe.Application\Common\Behaviours\ValidationPipelineBehaviour.cs:line 56
at OweMe.Application.Common.Behaviours.ValidationPipelineBehaviour`2.Handle(TRequest request, RequestHandlerDelegate`1 next, CancellationToken cancellationToken) in C:\Users\mszo\source\personal\owe-me-api\src\OweMe.Application\Common\Behaviours\ValidationPipelineBehaviour.cs:line 24
at OweMe.Application.Common.Behaviours.PerformancePipelineBehaviour`2.Handle(TRequest request, RequestHandlerDelegate`1 next, CancellationToken cancellationToken) in C:\Users\mszo\source\personal\owe-me-api\src\OweMe.Application\Common\Behaviours\PerformancePipelineBehaviour.cs:line 21
at OweMe.Application.Common.Behaviours.LoggingPipelineBehaviour`2.Handle(TRequest request, RequestHandlerDelegate`1 next, CancellationToken cancellationToken) in C:\Users\mszo\source\personal\owe-me-api\src\OweMe.Application\Common\Behaviours\LoggingPipelineBehaviour.cs:line 19
at OweMe.Api.Controllers.LedgersController.CreateLedger(CreateLedgerCommand createLedgerCommand, IMediator mediator) in C:\Users\mszo\source\personal\owe-me-api\src\OweMe.Api\Controllers\LedgersController.cs:line 34
at Microsoft.AspNetCore.Http.RequestDelegateFactory.ExecuteTaskResult[T](Task`1 task, HttpContext httpContext)
at Microsoft.AspNetCore.Http.RequestDelegateFactory.<>c__DisplayClass101_2.<<HandleRequestBodyAndCompileRequestDelegateForJson>b__2>d.MoveNext()
--- End of stack trace from previous location ---
at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|7_0(Endpoint endpoint, Task requestTask, ILogger logger)
at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
at Serilog.AspNetCore.RequestLoggingMiddleware.Invoke(HttpContext httpContext)
at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)
HEADERS
=======
Accept: */*
Connection: keep-alive
Host: localhost:8081
User-Agent: PostmanRuntime/7.44.1
Accept-Encoding: gzip, deflate, br
Authorization: Bearer <token>
Cache-Control: no-cache
Content-Type: application/json
Content-Length: 47
Postman-Token: fe5c0291-24fc-49f7-b83f-d570ebda3faa
`