### PR TITLE
refactor: use Assembly attributes to retrieve build version

### DIFF
--- a/api/src/OweMe.Api/Description/ApiInformationProvider.cs
+++ b/api/src/OweMe.Api/Description/ApiInformationProvider.cs
@@ -11,7 +11,7 @@ public class ApiInformationProvider : IApiInformationProvider
             Title = OweMeApiInformation.Title,
             Version = OweMeApiInformation.Version,
             Description = OweMeApiInformation.Description,
-            BuildVersion = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion,
+            BuildVersion = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
         };
     }
 

--- a/api/src/OweMe.Api/Description/ApiInformationProvider.cs
+++ b/api/src/OweMe.Api/Description/ApiInformationProvider.cs
@@ -11,7 +11,7 @@ public class ApiInformationProvider : IApiInformationProvider
             Title = OweMeApiInformation.Title,
             Version = OweMeApiInformation.Version,
             Description = OweMeApiInformation.Description,
-            BuildVersion = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
+            BuildVersion = typeof(ApiInformationProvider).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
         };
     }
 

--- a/api/src/OweMe.Api/Description/ApiInformationProvider.cs
+++ b/api/src/OweMe.Api/Description/ApiInformationProvider.cs
@@ -1,4 +1,6 @@
-﻿namespace OweMe.Api.Description;
+﻿using System.Reflection;
+
+namespace OweMe.Api.Description;
 
 public class ApiInformationProvider : IApiInformationProvider
 {
@@ -9,7 +11,7 @@ public class ApiInformationProvider : IApiInformationProvider
             Title = OweMeApiInformation.Title,
             Version = OweMeApiInformation.Version,
             Description = OweMeApiInformation.Description,
-            BuildVersion = ThisAssembly.AssemblyInformationalVersion
+            BuildVersion = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion,
         };
     }
 

--- a/api/tests/OweMe.Api.Tests/Description/ApiInformationProviderTests.cs
+++ b/api/tests/OweMe.Api.Tests/Description/ApiInformationProviderTests.cs
@@ -18,7 +18,7 @@ public class ApiInformationProviderTests
         // Assert
         apiInfo.ShouldNotBeNull();
         apiInfo.Version.ShouldBe("1.0.1");
-        apiInfo.BuildVersion.ShouldBe(Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion); // Assuming version is set the same in all projects.
+        apiInfo.BuildVersion.ShouldBe(Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown"); // Assuming version is set the same in all projects.
         apiInfo.Description.ShouldBe("API for OweMe application");
         apiInfo.Title.ShouldBe("OweMe API");
     }

--- a/api/tests/OweMe.Api.Tests/Description/ApiInformationProviderTests.cs
+++ b/api/tests/OweMe.Api.Tests/Description/ApiInformationProviderTests.cs
@@ -18,7 +18,7 @@ public class ApiInformationProviderTests
         // Assert
         apiInfo.ShouldNotBeNull();
         apiInfo.Version.ShouldBe("1.0.1");
-        apiInfo.BuildVersion.ShouldBe(ThisAssembly.AssemblyInformationalVersion); // Assuming ThisAssembly.AssemblyVersion is set the same in all projects.
+        apiInfo.BuildVersion.ShouldBe(Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion); // Assuming version is set the same in all projects.
         apiInfo.Description.ShouldBe("API for OweMe application");
         apiInfo.Title.ShouldBe("OweMe API");
     }

--- a/api/tests/OweMe.Api.Tests/Description/ApiInformationProviderTests.cs
+++ b/api/tests/OweMe.Api.Tests/Description/ApiInformationProviderTests.cs
@@ -18,7 +18,7 @@ public class ApiInformationProviderTests
         // Assert
         apiInfo.ShouldNotBeNull();
         apiInfo.Version.ShouldBe("1.0.1");
-        apiInfo.BuildVersion.ShouldBe(Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown"); // Assuming version is set the same in all projects.
+        apiInfo.BuildVersion.ShouldBe(typeof(ApiInformationProvider).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown"); // Assuming version is set the same in all projects.
         apiInfo.Description.ShouldBe("API for OweMe application");
         apiInfo.Title.ShouldBe("OweMe API");
     }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0-beta",
+  "version": "1.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
- Replace ThisAssembly references with Assembly.GetEntryAssembly() and AssemblyInformationalVersionAttribute
- Update version configuration from "1.0-beta" to "1.0" in version.json