### PR TITLE
ci: fix dotCover command in build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Test with coverage
         run: |
-          dotCover cover-dotnet \
+          dotCover cover \
             --reportType=HTML \
             --AttributeFilters=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute \
             --Output=dotCover.Output.html \


### PR DESCRIPTION
Due to `dotcover` changes and removing of dotnet-cover command, I need to change how I run this tool.

You can find these release notes below:

Performance refinements 2025.2

This release brings performance optimizations and a more streamlined experience to dotCover by focusing on modern, actively used technologies. To reduce overhead and improve coverage performance, we’ve retired support for features and technologies with minimal usage, based on current data.
Changes to runtime and framework support

Mono and Unity projects are no longer supported. Unity support will return once its runtime transitions to CoreCLR.

We’ve also phased out coverage support for legacy or rarely used application types, including:

    IIS Express
    WCF
    WinRT
    External .NET processes
    Mono (all variants)
    MAUI

These changes allow us to concentrate development efforts on the technologies most relevant to the majority of our users.
Command-line runner improvements

We’ve modernized the command-line runner to make it more consistent and aligned with current development workflows:

    **The cover-dotnet command has been unified under a single dotcover cover command for all target types. If no --targetExecutable is specified, dotCover will try to automatically detect the appropriate dotnet executable.**
    XML-based configuration files are no longer supported. Instead, you can use plain-text files with command-line arguments, for example, dotcover cover @args.txt.
    The standalone dotcover.exe runner has been removed from the NuGet package. The CLI runner is now available exclusively as a .NET global or local tool (requires .NET 6 or later).

